### PR TITLE
Annotate at @throws \ErrorException at AbstractChannel::wait

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -319,6 +319,7 @@ abstract class AbstractChannel
      * @param int $timeout
      * @throws \PhpAmqpLib\Exception\AMQPOutOfBoundsException
      * @throws \PhpAmqpLib\Exception\AMQPRuntimeException
+     * @throws \ErrorException
      * @return mixed
      */
     public function wait($allowed_methods = null, $non_blocking = false, $timeout = 0)


### PR DESCRIPTION
Thrown at \PhpAmqpLib\Wire\IO\StreamIO::error_handler

This probably is solved at #564, but at least the annotation would be useful